### PR TITLE
Fix dpi scaling

### DIFF
--- a/egui/src/main.rs
+++ b/egui/src/main.rs
@@ -653,11 +653,14 @@ fn run_ui(attractor_config: AttractorConfig, fullscreen: bool) {
 
                             let delta_a: f64 = a - last_a;
 
+                            let ox = cx * gui_state.multisampling as f64;
+                            let oy = cy * gui_state.multisampling as f64;
+
                             // Rot(x - c) + c => Rot(x) + (c - Rot(c))
                             let mat = [delta_a.cos(), delta_a.sin(), -delta_a.sin(), delta_a.cos()];
                             let trans = [
-                                cx - mat[0] * cx - mat[1] * cy,
-                                cy - mat[2] * cx - mat[3] * cy,
+                                ox - mat[0] * ox - mat[1] * oy,
+                                oy - mat[2] * ox - mat[3] * oy,
                             ];
 
                             let _ = attractor_sender.send(AttractorMess::Transform((mat, trans)));

--- a/egui/src/main.rs
+++ b/egui/src/main.rs
@@ -1309,7 +1309,7 @@ fn render_frame(
     });
     let screen_descriptor = egui_wgpu::renderer::ScreenDescriptor {
         size_in_pixels: [render_state.surface.size().0, render_state.surface.size().1],
-        pixels_per_point: 1.0,
+        pixels_per_point: egui_ctx.pixels_per_point(),
     };
     render_state.attractor_renderer.update_uniforms(queue);
     render_state.egui_renderer.update_buffers(


### PR DESCRIPTION
Close #8.

DPI was already handled, the only problem was that `pixels_per_point` was hard coded to `1.0` instead of the correct value. Also fixed an error when rotating the attractor when `multisampling > 1`, the rotation was off-center.