### PR TITLE
Don't load shader from disk

### DIFF
--- a/render/src/renderer.rs
+++ b/render/src/renderer.rs
@@ -765,9 +765,6 @@ fn create_render_pipeline(
     pipeline_layout: &wgpu::PipelineLayout,
     multisampling: u8,
 ) -> Result<RenderPipeline, Box<dyn Error>> {
-    #[cfg(not(target_os = "android"))]
-    let mut source = std::fs::read_to_string("render/src/shader.wgsl")?;
-    #[cfg(target_os = "android")]
     let mut source = include_str!("shader.wgsl").to_string();
 
     source = source.replace("MULTISAMPLING", &format!("{}u", multisampling));


### PR DESCRIPTION
Fix error reported in https://github.com/Rodrigodd/attractor-wallpaper/pull/7#issuecomment-1932655475.

For debugging purposes, the program was loading the shader from disk, but this only work when running it from from the project root.